### PR TITLE
Make image usable with `docker run`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir /template
 RUN mkdir /ssl
 
 COPY cert.conf /template/cert.conf
-COPY nginx-default.conf /etc/nginx/conf.d/default.conf
+COPY nginx-default.conf /template/nginx-default.conf
 
 COPY run.sh /run.sh
 RUN chmod +x /run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM nginx:1.13
 
+ENV DNS_RESOLVER="127.0.0.11"
 ENV REMOTE_URL="http://localhost:8080/"
 ENV CERT_CN="localhost"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.13
 
-ENV DNS_RESOLVER="127.0.0.11"
+ENV DNS_RESOLVER="auto"
 ENV REMOTE_URL="http://localhost:8080/"
 ENV CERT_CN="localhost"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM nginx:1.13
 
-ENV DNS_RESOLVER="127.0.0.11"
-ENV REMOTE_URL="http://localhost:8080/"
+ENV REMOTE_URL=""
 ENV CERT_CN="localhost"
+ENV DNS_RESOLVER="127.0.0.11"
 
 RUN apt-get update
 RUN apt-get install openssl -y

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Variable name | Default value
 --------------|------------------------
 REMOTE_URL    | http://localhost:8080/
 CERT_CN       | localhost
-DNS_RESOLVER  | 127.0.0.11
+DNS_RESOLVER  | auto
 
 
 ## Sample Usage
@@ -60,7 +60,7 @@ Sometimes, you may see something like this in the ouput:
 
 > recv() failed (111: Connection refused) while resolving, resolver: 127.0.0.11:53
 
-This most likely indicates that the DNS resolver doesn't exist on the default address (127.0.0.11).
+This indicates that the image failed to determine what IP to use as DNS resolver.
 There are two possible remedies in this situation:
 
 1. Use the DNS resolver that was configured for your container.
@@ -84,7 +84,7 @@ There are two possible remedies in this situation:
 
     Then, pass it as `--net` parameter when running the container:
     ```
-    docker run --rm -p 443:443 -p 80:80 -e REMOTE_URL=http://host.docker.internal:5000 --net=local bostonuniversity/elb-simulator:latest
+    docker run --rm -p 443:443 -p 80:80 -e REMOTE_URL=http://host.docker.internal:5000 -e DNS_RESOLVER=127.0.0.11 --net=local bostonuniversity/elb-simulator:latest
     ```
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This docker image tries to simulate the behavior of Amazon ELB and can be used
 to locally debug the webserver ECS containers that run behind ELB.
 
 This image also can be used as SSL terminating proxy. By default, it will generate
-a self-signed certificate for `localhost` and route the traffic to `http://localhost:8080/`.
+a self-signed certificate for `localhost`.
 This, along with other options, can be changed by setting environment variables.
 
 
@@ -12,7 +12,7 @@ This, along with other options, can be changed by setting environment variables.
 
 Variable name | Default value
 --------------|------------------------
-REMOTE_URL    | http://localhost:8080/
+REMOTE_URL    | -
 CERT_CN       | localhost
 DNS_RESOLVER  | 127.0.0.11
 

--- a/README.md
+++ b/README.md
@@ -5,17 +5,34 @@ to locally debug the webserver ECS containers that run behind ELB.
 
 This image also can be used as SSL terminating proxy. By default, it will generate
 a self-signed certificate for `localhost` and route the traffic to `http://localhost:8080/`.
-This can be changed by setting environment variables:
+This, along with other options, can be changed by setting environment variables.
+
+
+## Environment Variables
 
 Variable name | Default value
 --------------|------------------------
-DNS_RESOLVER  | 127.0.0.11
 REMOTE_URL    | http://localhost:8080/
 CERT_CN       | localhost
+DNS_RESOLVER  | 127.0.0.11
 
-## Usage
 
-Using `docker-compose`:
+## Sample Usage
+
+#### Using `docker`
+
+The command below assumes that you have a local webserver running on port 5000
+but you want to be able to access it via 
+either http://localhost or https://localhost instead.
+```
+docker run --rm -p 443:443 -p 80:80 -e REMOTE_URL=http://host.docker.internal:5000 bostonuniversity/elb-simulator:latest
+```
+
+#### Using `docker-compose`
+
+The config below assumes that you have a service named `http_webserver`
+running on port 8000 but you want to be able to access it via 
+either http://localhost or https://localhost instead.
 ```
 version: "3.7"
 
@@ -26,7 +43,7 @@ services:
       - "80:80"
       - "443:443"
     environment:
-      REMOTE_URL: "http://http_webserver:80"
+      REMOTE_URL: "http://http_webserver:8000"
     depends_on:
       - "http_webserver"
 
@@ -34,7 +51,44 @@ services:
   ...
 ```
 
-### Persist generated certificate
+
+## Troubleshooting
+
+#### Missing Resolver
+
+Sometimes, you may see something like this in the ouput:
+
+> recv() failed (111: Connection refused) while resolving, resolver: 127.0.0.11:53
+
+This most likely indicates that the DNS resolver doesn't exist on the default address (127.0.0.11).
+There are two possible remedies in this situation:
+
+1. Use the DNS resolver that was configured for your container.
+    To find the address of the resolver, run: 
+    ```
+    docker run --rm bostonuniversity/elb-simulator:latest cat /etc/resolv.conf
+    ```
+
+    In the output, find the line that starts with `nameserver`
+    and then pass that IP as the `DNS_RESOLVER` environment variable to the container:
+    ```
+    docker run --rm -p 443:443 -p 80:80 -e REMOTE_URL=http://host.docker.internal:5000 -e DNS_RESOLVER=192.168.100.1 bostonuniversity/elb-simulator:latest
+    ```
+
+1. Force the creation of the DNS resolver on 127.0.0.11 
+    by running your docker container inside the custom network.
+    First, create the network:
+    ```
+    docker network create local
+    ```
+
+    Then, pass it as `--net` parameter when running the container:
+    ```
+    docker run --rm -p 443:443 -p 80:80 -e REMOTE_URL=http://host.docker.internal:5000 --net=local bostonuniversity/elb-simulator:latest
+    ```
+
+
+## Persist generated certificate
 
 The container checks if the file `/ssl/cert.crt` exists and regenerates the
 certificate if it doesn't. This may cause issues if you're planning to install
@@ -64,7 +118,7 @@ services:
   ...
 ```
 
-### Install certificate into your OS
+#### Install certificate into your OS
 
 For Mac, run:
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This can be changed by setting environment variables:
 
 Variable name | Default value
 --------------|------------------------
+DNS_RESOLVER  | 127.0.0.11
 REMOTE_URL    | http://localhost:8080/
 CERT_CN       | localhost
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,14 @@ this certificate into your OS to avoid security warnings in browsers.
 Mount a volume into `/ssl` in your container. This way, even after rebuilding
 the container, you'll keep using the same certificate.
 
-Using `docker-compose`:
+#### Using `docker`
+
+```
+docker run --rm -p 443:443 -p 80:80 -e REMOTE_URL=http://host.docker.internal:5000 -v $(pwd)/ssl:/ssl bostonuniversity/elb-simulator:latest
+```
+
+#### Using `docker-compose`
+
 ```
 version: "3.7"
 
@@ -108,7 +115,7 @@ services:
       - "80:80"
       - "443:443"
     environment:
-      REMOTE_URL: "http://http_webserver:80"
+      REMOTE_URL: "http://http_webserver:8000"
     depends_on:
       - "http_webserver"
     volumes:
@@ -118,7 +125,7 @@ services:
   ...
 ```
 
-#### Install certificate into your OS
+### Install certificate into your OS
 
 For Mac, run:
 ```

--- a/nginx-default.conf
+++ b/nginx-default.conf
@@ -11,12 +11,12 @@ server {
     ssl_prefer_server_ciphers on;
 
     location / {
-        resolver XX_DNS_RESOLVER_XX ipv6=off; #Specify docker's embedded DNS server
+        resolver $DNS_RESOLVER ipv6=off; #Specify docker's embedded DNS server
         proxy_set_header    Host $host;
         proxy_set_header    X-Real-IP $remote_addr;
         proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header    X-Forwarded-Proto $scheme;
-        proxy_pass          XX_REMOTE_URL_XX$request_uri;
+        proxy_pass          $REMOTE_URL$request_uri;
         proxy_read_timeout  600;
     }
 }

--- a/nginx-default.conf
+++ b/nginx-default.conf
@@ -11,7 +11,7 @@ server {
     ssl_prefer_server_ciphers on;
 
     location / {
-        resolver 127.0.0.11 ipv6=off; #Specify docker's embedded DNS server
+        resolver XX_DNS_RESOLVER_XX ipv6=off; #Specify docker's embedded DNS server
         proxy_set_header    Host $host;
         proxy_set_header    X-Real-IP $remote_addr;
         proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-sed -i -e "s|XX_REMOTE_URL_XX|$REMOTE_URL|g" /etc/nginx/conf.d/default.conf
-sed -i -e "s|XX_DNS_RESOLVER_XX|$DNS_RESOLVER|g" /etc/nginx/conf.d/default.conf
+# Specify which environment variables to substitute
+vars_to_sub='$REMOTE_URL:$DNS_RESOLVER'
+
+# Substitute environment variables
+envsubst "$vars_to_sub" < /template/nginx-default.conf > /etc/nginx/conf.d/default.conf
 
 exec nginx -g "daemon off;"

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 sed -i -e "s|XX_REMOTE_URL_XX|$REMOTE_URL|g" /etc/nginx/conf.d/default.conf
+sed -i -e "s|XX_DNS_RESOLVER_XX|$DNS_RESOLVER|g" /etc/nginx/conf.d/default.conf
 
 exec nginx -g "daemon off;"

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Set default value for DNS_RESOLVER to the first nameserver value found in /etc/resolv.conf
+if [ "$DNS_RESOLVER" = 'auto' ]; then
+  export DNS_RESOLVER=$(sed -n -e 's/^.*nameserver //p' < /etc/resolv.conf | head -n 1)
+fi
+
 # Specify which environment variables to substitute
 vars_to_sub='$REMOTE_URL:$DNS_RESOLVER'
 


### PR DESCRIPTION
- Adds DNS_RESOLVER environment variable that allows to specify what DNS resolver will be used by nginx behind the scenes.
- Adds sample `docker run` commands to README.
- Removes the default value of REMOTE_URL environment variable.